### PR TITLE
Integrate build-infra for setting versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,6 @@
 pipeline {
     agent {
         label 'testintegration'
-//        docker {
-//            image 'docker.io/manics/omero-build-gradle:latest'
-//        }
     }
 
     environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,17 @@ pipeline {
     }
 
     stages {
+        stage('Versions') {
+            steps {
+                // build is in .gitignore so we can use it as a temp dir
+                sh 'mkdir build'
+                sh 'cd build && curl -sfL https://github.com/ome/build-infra/archive/master.tar.gz | tar -zxf -'
+                sh """
+                    foreach-get-version-as-property >> version.properties
+                """
+                archiveArtifacts artifacts: 'version.properties'
+            }
+        }
         stage('Build') {
             steps {
                 // Currently running on a build node with multiple jobs so incorrect jar may be cached
@@ -24,9 +35,6 @@ pipeline {
         stage('Deploy') {
             steps {
                 sh 'gradle --init-script init-ci.gradle publish'
-                sh 'git clone git://github.com/ome/build-infra .build'
-                sh 'env PATH=$PATH:.build foreach-get-version-as-property >> versions'
-                archiveArtifacts artifacts: 'versions'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,9 +17,11 @@ pipeline {
         stage('Versions') {
             steps {
                 // build is in .gitignore so we can use it as a temp dir
-                sh 'mkdir build'
-                sh 'cd build && curl -sfL https://github.com/ome/build-infra/archive/master.tar.gz | tar -zxf -'
                 sh """
+                    mkdir ${env.WORKSPACE}/build
+                    cd ${env.WORKSPACE}/build && curl -sfL https://github.com/ome/build-infra/archive/master.tar.gz | tar -zxf -
+                    export PATH=$PATH:${env.WORKSPACE}/build/build-infra-master/
+                    cd ..
                     foreach-get-version-as-property >> version.properties
                 """
                 archiveArtifacts artifacts: 'version.properties'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
         stage('Deploy') {
             steps {
                 sh 'gradle --init-script init-ci.gradle publish'
+                sh 'git clone git://github.com/ome/build-infra .build'
+                sh 'env PATH=$PATH:.build foreach-get-version-as-property >> versions'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
                 sh 'gradle --init-script init-ci.gradle publish'
                 sh 'git clone git://github.com/ome/build-infra .build'
                 sh 'env PATH=$PATH:.build foreach-get-version-as-property >> versions'
+                archiveArtifacts artifacts: 'versions'
             }
         }
     }


### PR DESCRIPTION
This seeks to copy the strategy used in [travis.sh](https://github.com/ome/omero-build/blob/master/travis.sh#L16) to tie the build versions together in the openmicroscopy/openmicroscopy build. To keep the two nicely separate, this solely prints out the versions as Java properties to a file. A later job can then make use of those.