### PR TITLE
Jenkinsfile optional copy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         stage('Versions') {
             steps {
 
-                copyArtifacts(projectName: 'OMERO-gradle-plugins-build', flatten: true, filter: 'version.properties')
+                copyArtifacts(projectName: 'OMERO-gradle-plugins-build', flatten: true, filter: 'version.properties', optional: true)
 
                 // build is in .gitignore so we can use it as a temp dir
                 sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                     cd ..
                     # Workaround for "unflattened" file, possibly due to matrix
                     find . -name version.properties -exec cp {} . \\;
-                    test -e version.properties
+                    test -e version.properties || touch version.properties
                     foreach-get-version-as-property >> version.properties
                 """
                 archiveArtifacts artifacts: 'version.properties'


### PR DESCRIPTION
The current version of the `Jenkinsfile` works without issue in the default workflow where all components are built in order including https://github.com/ome/omero-gradle-plugins.

Similarly to https://github.com/ome/jenkins-library-recursivemerge/pull/2, this PR extends the logic to depend conditionally on upstream artifacts using the `optional` option of the `copyArtifacts` pipeline step and create a mock version.properties