### PR TITLE
Archive python zips from omero-blitz

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
                 // Currently running on a build node with multiple jobs so incorrect jar may be cached
                 // (Moving to Docker should fix this)
                 sh 'gradle --init-script init-ci.gradle publishToMavenLocal --refresh-dependencies'
+                archiveArtifacts artifacts: 'omero-blitz/build/**/*python.zip'
             }
         }
         stage('Deploy') {


### PR DESCRIPTION
This is a possibly temporary workaround for the difficulty of
finding the proper SNAPSHOT version for downloading the correct
python zip.